### PR TITLE
feat: add the is inline directive to supress warnings dring build for unoptimized scripts

### DIFF
--- a/src/components/astro/json-lds/breadcrumb.astro
+++ b/src/components/astro/json-lds/breadcrumb.astro
@@ -40,4 +40,4 @@ const breadcrumbJsonLd = {
 };
 ---
 
-<script type="application/ld+json" set:html={JSON.stringify(breadcrumbJsonLd)} />
+<script type="application/ld+json" is:inline set:html={JSON.stringify(breadcrumbJsonLd)} />

--- a/src/components/astro/json-lds/profile-page.astro
+++ b/src/components/astro/json-lds/profile-page.astro
@@ -1,4 +1,4 @@
-<script type="application/ld+json">
+<script type="application/ld+json" is:inline>
 	{
 		"@context": "https://schema.org",
 		"@type": "ProfilePage",


### PR DESCRIPTION
Add `is:inline` directive to remove warning during build as we don't want any optimizations or bundling on them.

Ref: https://docs.astro.build/en/reference/directives-reference/#isinline