### PR TITLE
fix: Seo Meta tags for twitter

### DIFF
--- a/src/components/astro/seo-meta/index.astro
+++ b/src/components/astro/seo-meta/index.astro
@@ -46,6 +46,6 @@ const formattedDescription = description.replaceAll('{{year}}', new Date().getFu
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:site" content="@abhushanaj" />
 <meta name="twitter:creator" content="@abhushanaj" />
-<meta property="twitter:title" content={formattedSeoTitle} />
-<meta property="twitter:description" content={formattedDescription} />
-<meta property="twitter:image" content={ogImage} />
+<meta name="twitter:title" content={formattedSeoTitle} />
+<meta name="twitter:description" content={formattedDescription} />
+<meta name="twitter:image" content={ogImage} />


### PR DESCRIPTION
In the meta element for Twitter, the attribute should be `name` rather than `property`. You can verify this using the Social Share Preview tool at: https://socialsharepreview.com/?url=https://abhushan.dev.